### PR TITLE
Fix(modal): Se corrige bug al cerrar modales

### DIFF
--- a/app/views/admin/configuracion.php
+++ b/app/views/admin/configuracion.php
@@ -22,7 +22,7 @@
     <?= $component['nav'] ?? '' ?>
 
     <!--ModalNewMessage-->
-    <div class="modal fade" id="modalNewMessage" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
+    <div class="modal " id="modalNewMessage" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
         <div class="modal-dialog text-black">
             <div class="modal-content">
                 <div class="modal-header">
@@ -53,7 +53,7 @@
     </div>
 
     <!--ModalNewEndPoint-->
-    <div class="modal fade" id="modalNewEnd" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
+    <div class="modal " id="modalNewEnd" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
         <div class="modal-dialog text-black">
             <div class="modal-content">
                 <div class="modal-header">
@@ -83,7 +83,7 @@
     </div>
 
     <!--ModalEditMessage-->
-    <div class="modal fade" id="modalEditMessage" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
+    <div class="modal " id="modalEditMessage" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
         <div class="modal-dialog text-black">
             <div class="modal-content">
                 <div class="modal-header">
@@ -114,7 +114,7 @@
     </div>
 
     <!--ModalEditEndpoint-->
-    <div class="modal fade" id="modalEditEndpoint" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
+    <div class="modal " id="modalEditEndpoint" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
         <div class="modal-dialog text-black">
             <div class="modal-content">
                 <div class="modal-header">
@@ -144,7 +144,7 @@
     </div>
 
     <!--ModalDelete-->
-    <div class="modal fade" id="modalDelete" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
+    <div class="modal " id="modalDelete" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
         <div class="modal-dialog text-black">
             <div class="modal-content">
                 <div class="modal-header">

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -42,7 +42,7 @@
     </div>
 
     <!--ModalConte-->
-    <div class="modal fade" id="modalCont" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
+    <div class="modal " id="modalCont" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
         <div class="modal-dialog text-black">
             <div class="modal-content">
                 <div class="modal-header">
@@ -85,7 +85,7 @@
     </div>
 
     <!--ModalSub-->
-    <div class="modal fade" id="modalSus" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
+    <div class="modal " id="modalSus" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1">
         <div class="modal-dialog text-black">
             <div class="modal-content">
                 <div class="modal-header">

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -17,6 +17,14 @@ $(document).ready(function () {
     });
 });
 
+document.addEventListener("DOMContentLoaded", function () {
+    document.addEventListener('hidden.bs.modal', function () {
+        if (document.activeElement) {
+            document.activeElement.blur();
+        }
+    });
+});
+
 hashCode = s => s.split('').reduce((a, b) => { a = ((a << 5) - a) + b.charCodeAt(0); return a & a }, 0)
 
 function getCode(input) {


### PR DESCRIPTION
Se implementa en el app.js despues de cargar el dom una funcion para quitar el foco que se queda del modal despues de cerrarlo ademas se elimina la class 'fade' de los modales
Cambios a ser confirmados:
 modificados:     app/views/admin/configuracion.php
 modificados:     app/views/home.php
 modificados:     public/assets/js/app.js